### PR TITLE
fix go.mod to be v2 matching the current major release/tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Privado-Inc/privado-cli
+module github.com/Privado-Inc/privado-cli/v2
 
 go 1.17
 


### PR DESCRIPTION
allow importing in go.mod by having package version match the git tagged version